### PR TITLE
Fix comment typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,7 +177,7 @@ cython_debug/
 #  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
-#  you could uncomment the following to ignore the enitre vscode folder
+#  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 
 # Ruff stuff:


### PR DESCRIPTION
## Summary
- correct spelling of 'entire' in .gitignore comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bdb6453608324b4eb378c5fa01d49